### PR TITLE
add initial .github/workflows/publish-to-npm-registry.yml (r4player)

### DIFF
--- a/.github/workflows/publish-to-npm-registry.yml
+++ b/.github/workflows/publish-to-npm-registry.yml
@@ -1,0 +1,20 @@
+# source: https://docs.github.com/en/actions/guides/publishing-nodejs-packages
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: alpine-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm Packages
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
An initial github action to publish the sdk as a npm module;

it will trigger each time there is a new tag `v*`, of the form `v0.0.1` samever versioning

the package should be `@radio4000/sdk` to be part of the correct organization on npm