### PR TITLE
channel methods/interface

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -18,8 +18,11 @@
 			// this "index.js" file is only present during `npm run dev`
 			import sdk from './index.js'
 
+			// For debugging
+			window.sdk = sdk
+
 			const ul = document.querySelector('#channels')
-			sdk.findChannels(10).then(response => {
+			sdk.findChannels(100).then(response => {
 				console.log(response.error, response.data)
 				for (const c of response.data) {
 					const li = document.createElement('li')

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"checkJs": true,
+		"target": "esnext",
+	},
+	"include": [
+		"src/**/*",
+		"tests/**/*"
+	],
+	"exclude": [
+		"node_modules"
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@radio4000/sdk",
-  "version": "0.0.2",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@radio4000/sdk",
-      "version": "0.0.2",
+      "version": "0.0.6",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@supabase/supabase-js": "^2.0.0"

--- a/src/auth.js
+++ b/src/auth.js
@@ -8,11 +8,11 @@ export const signUp = async ({email, password}) => {
 }
 
 export const signIn = async ({email, password}) => {
-	console.log('signin', email, password)
+	console.log('sign in', email, password)
 	return supabase.auth.signInWithPassword({email, password})
 }
 
 export const signOut = async () => {
-	console.log('signout')
+	console.log('sign out')
 	return supabase.auth.signOut()
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -3,16 +3,13 @@ import {supabase} from './supabase-client.js'
 // Three wrappers around the auth methods from Supabase.
 
 export const signUp = async ({email, password}) => {
-	console.log('sign up', email, password)
 	return supabase.auth.signUp({email, password})
 }
 
 export const signIn = async ({email, password}) => {
-	console.log('sign in', email, password)
 	return supabase.auth.signInWithPassword({email, password})
 }
 
 export const signOut = async () => {
-	console.log('sign out')
 	return supabase.auth.signOut()
 }

--- a/src/channel.js
+++ b/src/channel.js
@@ -1,36 +1,51 @@
 import {supabase} from './supabase-client.js'
 
-export const createChannel = async ({channel, user}) => {
-	const {name, slug} = channel
-	const {id: user_id} = user
+/**
+ * Creates a new radio channel
+ * @param {string} user_id
+ * @param {{name: string, slug: string}} fields
+ * @return {Promise<object>} {data, error}
+ */
+export const createChannel = async (user_id, {name, slug}) => {
 
 	// Throw an error if the slug is in use by the old Firebase database.
 	const queryFirebaseDb = await firebaseGetChannelBySlug(slug)
 	const isSlugTaken = Object.keys(queryFirebaseDb).length > 0
-	if (isSlugTaken) throw new Error('Sorry. This channel slug is already taken by someone else.')
+	if (isSlugTaken) return {error: Error('Sorry. This channel slug is already taken by someone else.')}
 
 	// Create channel
-	const channelResponse = await supabase.from('channels').insert({name, slug}).single()
+	const channelRes = await supabase.from('channels').insert({name, slug}).single().select()
 
 	// Stop if the first query failed.
-	if (channelResponse.error) return channelResponse
+	if (channelRes.error) return channelRes
 
 	// Create junction table
-	const channel_id = channelResponse.data.id
-	const userChannelResponse = await supabase.from('user_channel').insert({user_id, channel_id}).single()
-	if (userChannelResponse.error) return userChannelResponse
+	const channel_id = channelRes.data.id
+	const userChannelRes = await supabase.from('user_channel').insert({user_id, channel_id}).single()
+	if (userChannelRes.error) return userChannelRes
 
 	// Return both records of the channel
-	return {data: {channel: channelResponse.data, userChannel: userChannelResponse.data}}
+	return {data: channelRes.data}
 }
 
-export const updateChannel = async ({id, changes}) => {
+/**
+ * Updates a channel
+ * @param {string} id
+ * @param {{name: string, slug: string, description: string}} changes - optional fields to update
+ * @returns
+ */
+export const updateChannel = async (id, changes) => {
 	console.log('updating channel', id, changes)
 	const {name, slug, description} = changes
 	return supabase.from('channels').update({name, slug, description}).eq('id', id)
 }
 
-export const deleteChannel = async ({id}) => {
+/**
+ *
+ * @param {string} id
+ * @returns
+ */
+export const deleteChannel = async (id) => {
 	if (!id) return
 	console.log('deleting channel', id)
 	return supabase.from('channels').delete().eq('id', id)

--- a/src/channel.js
+++ b/src/channel.js
@@ -44,7 +44,7 @@ export const createChannel = async ({name, slug}) => {
  * @param {string} [changes.name]
  * @param {string} [changes.slug]
  * @param {string} [changes.description]
- * @returns {Promise}
+ * @returns {Promise<object>}
  */
 export const updateChannel = async (id, changes) => {
 	const {name, slug, description} = changes
@@ -66,9 +66,9 @@ export const findChannelBySlug = async (slug) => {
 }
 
 /**
- *
+ * Returns a list of channels.
  * @param {number} limit
- * @returns
+ * @returns {Promise<object>}
  */
 export const findChannels = async (limit = 1000) => {
 	return supabase.from('channels').select('*').limit(limit).order('created_at', {ascending: true})

--- a/src/channel.js
+++ b/src/channel.js
@@ -47,7 +47,6 @@ export const createChannel = async ({name, slug}) => {
  * @returns {Promise}
  */
 export const updateChannel = async (id, changes) => {
-	console.log('updating channel', id, changes)
 	const {name, slug, description} = changes
 	return supabase.from('channels').update({name, slug, description}).eq('id', id)
 }
@@ -59,7 +58,6 @@ export const updateChannel = async (id, changes) => {
  */
 export const deleteChannel = async (id) => {
 	if (!id) return
-	console.log('deleting channel', id)
 	return supabase.from('channels').delete().eq('id', id)
 }
 

--- a/src/channel.js
+++ b/src/channel.js
@@ -1,13 +1,20 @@
 import {supabase} from './supabase-client.js'
 
 /**
- * Creates a new radio channel
+ * A channel
+ * @typedef {Object} Channel
+ * @property {string} name
+ * @property {string} slug - unique
+ * @property {string} [description]
+ */
+
+/**
+ * Creates a new radio channel and connects it to a user
  * @param {string} user_id
- * @param {{name: string, slug: string}} fields
+ * @param {Channel} fields
  * @return {Promise<object>} {data, error}
  */
 export const createChannel = async (user_id, {name, slug}) => {
-
 	// Throw an error if the slug is in use by the old Firebase database.
 	const queryFirebaseDb = await firebaseGetChannelBySlug(slug)
 	const isSlugTaken = Object.keys(queryFirebaseDb).length > 0
@@ -31,8 +38,11 @@ export const createChannel = async (user_id, {name, slug}) => {
 /**
  * Updates a channel
  * @param {string} id
- * @param {{name: string, slug: string, description: string}} changes - optional fields to update
- * @returns
+ * @param {object} changes - optional fields to update
+ * @param {string} [changes.name]
+ * @param {string} [changes.slug]
+ * @param {string} [changes.description]
+ * @returns {Promise}
  */
 export const updateChannel = async (id, changes) => {
 	console.log('updating channel', id, changes)
@@ -41,9 +51,9 @@ export const updateChannel = async (id, changes) => {
 }
 
 /**
- *
+ * Deletes a channel
  * @param {string} id
- * @returns
+ * @returns void
  */
 export const deleteChannel = async (id) => {
 	if (!id) return
@@ -51,11 +61,18 @@ export const deleteChannel = async (id) => {
 	return supabase.from('channels').delete().eq('id', id)
 }
 
-export const findChannelBySlug = async (slug) =>
-	supabase.from('channels').select(`*`).eq('slug', slug).single()
+export const findChannelBySlug = async (slug) => {
+	return supabase.from('channels').select(`*`).eq('slug', slug).single()
+}
 
-export const findChannels = async (limit = 1000) =>
-	supabase.from('channels').select('*').limit(limit).order('created_at', {ascending: true})
+/**
+ *
+ * @param {number} limit
+ * @returns
+ */
+export const findChannels = async (limit = 1000) => {
+	return supabase.from('channels').select('*').limit(limit).order('created_at', {ascending: true})
+}
 
 export async function firebaseGetChannelBySlug(slug) {
 	const res = await fetch(`https://radio4000.firebaseio.com/channels.json?orderBy="slug"&equalTo="${slug}"`)

--- a/src/channel.js
+++ b/src/channel.js
@@ -1,4 +1,5 @@
 import {supabase} from './supabase-client.js'
+import {getUser} from './user.js'
 
 /**
  * A channel
@@ -10,11 +11,12 @@ import {supabase} from './supabase-client.js'
 
 /**
  * Creates a new radio channel and connects it to a user
- * @param {string} user_id
  * @param {Channel} fields
  * @return {Promise<object>} {data, error}
  */
-export const createChannel = async (user_id, {name, slug}) => {
+export const createChannel = async ({name, slug}) => {
+	const user = await getUser()
+
 	// Throw an error if the slug is in use by the old Firebase database.
 	const queryFirebaseDb = await firebaseGetChannelBySlug(slug)
 	const isSlugTaken = Object.keys(queryFirebaseDb).length > 0
@@ -28,7 +30,7 @@ export const createChannel = async (user_id, {name, slug}) => {
 
 	// Create junction table
 	const channel_id = channelRes.data.id
-	const userChannelRes = await supabase.from('user_channel').insert({user_id, channel_id}).single()
+	const userChannelRes = await supabase.from('user_channel').insert({user_id: user.id, channel_id}).single()
 	if (userChannelRes.error) return userChannelRes
 
 	// Return both records of the channel

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 import { supabase } from './supabase-client.js'
 import { signUp, signIn, signOut } from './auth.js'
-import { deleteUser } from './user.js'
+import { getUser, deleteUser } from './user.js'
 import { createChannel, updateChannel, deleteChannel, findChannels, findChannelBySlug } from './channel.js'
 import { createTrack, updateTrack, deleteTrack } from './track.js'
 
 const sdk = {
 	supabase,
 	signUp, signIn, signOut,
-	deleteUser,
+	getUser, deleteUser,
 	createChannel, updateChannel, deleteChannel, findChannels, findChannelBySlug,
 	createTrack, updateTrack, deleteTrack
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 import { supabase } from './supabase-client.js'
 import { signUp, signIn, signOut } from './auth.js'
 import { deleteUser } from './user.js'
-import { createChannel, updateChannel, deleteChannel, findChannels } from './channel.js'
+import { createChannel, updateChannel, deleteChannel, findChannels, findChannelBySlug } from './channel.js'
 import { createTrack, updateTrack, deleteTrack } from './track.js'
 
 const sdk = {
 	supabase,
 	signUp, signIn, signOut,
 	deleteUser,
-	createChannel, updateChannel, deleteChannel, findChannels,
+	createChannel, updateChannel, deleteChannel, findChannels, findChannelBySlug,
 	createTrack, updateTrack, deleteTrack
 }
 

--- a/src/track.js
+++ b/src/track.js
@@ -42,13 +42,17 @@ export const createTrack = async (channelId, fields) => {
  * Updates a track
  * @param {string} id
  * @param {object} changes
- * @returns
+ * @returns {Promise}
  */
 export const updateTrack = async (id, changes) => {
 	const {url, title, description} = changes
 	return supabase.from('tracks').update({url, title, description}).eq('id', id)
 }
 
+/**
+ * Deletes a track
+ * @param {string} id
+ */
 export const deleteTrack = async (id) => {
 	if (!id) return
 	return supabase.from('tracks').delete().eq('id', id)

--- a/src/track.js
+++ b/src/track.js
@@ -1,7 +1,17 @@
 import {supabase} from './supabase-client.js'
 
-export const createTrack = async ({changes, channelId, userId}) => {
-	const {url, title, description} = changes
+/**
+ * Creates a track and connects it to a user and channel.
+ * @param {string} userId
+ * @param {string} channelId
+ * @param {object} fields
+ * @param {string} fields.url
+ * @param {string} fields.title
+ * @param {string} [fields.description]
+ * @return {Promise}
+ */
+export const createTrack = async (userId, channelId, fields) => {
+	const {url, title, description} = fields
 
 	if (!channelId) throw Error('Missing channel id')
 
@@ -10,6 +20,7 @@ export const createTrack = async ({changes, channelId, userId}) => {
 		.from('tracks')
 		.insert({url, title, description})
 		.single()
+		.select()
 	if (error) return {error}
 
 	// Create junction row
@@ -26,12 +37,18 @@ export const createTrack = async ({changes, channelId, userId}) => {
 	return {data: track}
 }
 
-export const updateTrack = async ({id, changes}) => {
+/**
+ * Updates a track
+ * @param {string} id
+ * @param {object} changes
+ * @returns
+ */
+export const updateTrack = async (id, changes) => {
 	const {url, title, description} = changes
 	return supabase.from('tracks').update({url, title, description}).eq('id', id)
 }
 
-export const deleteTrack = async ({track}) => {
-	if (!track.id) return
-	return supabase.from('tracks').delete().eq('id', track.id)
+export const deleteTrack = async (id) => {
+	if (!id) return
+	return supabase.from('tracks').delete().eq('id', id)
 }

--- a/src/track.js
+++ b/src/track.js
@@ -1,8 +1,8 @@
 import {supabase} from './supabase-client.js'
+import {getUser} from './user.js'
 
 /**
  * Creates a track and connects it to a user and channel.
- * @param {string} userId
  * @param {string} channelId
  * @param {object} fields
  * @param {string} fields.url
@@ -10,7 +10,7 @@ import {supabase} from './supabase-client.js'
  * @param {string} [fields.description]
  * @return {Promise}
  */
-export const createTrack = async (userId, channelId, fields) => {
+export const createTrack = async (channelId, fields) => {
 	const {url, title, description} = fields
 
 	if (!channelId) throw Error('Missing channel id')
@@ -24,12 +24,13 @@ export const createTrack = async (userId, channelId, fields) => {
 	if (error) return {error}
 
 	// Create junction row
+	const user = await getUser()
 	const {error2} = await supabase
 		.from('channel_track')
 		.insert({
 			track_id: track.id,
 			channel_id: channelId,
-			user_id: userId,
+			user_id: user.id,
 		})
 		.single()
 	if (error2) return {error}

--- a/src/user.js
+++ b/src/user.js
@@ -1,5 +1,11 @@
 import {supabase} from './supabase-client.js'
 
+export async function getUser() {
+	const {data, error} = await supabase.auth.getUser()
+	if (error) return {error}
+	return data.user
+}
+
 // Will delete the currently authenticated user's "auth user" and any "user channels".
 // The function is defined in https://github.com/internet4000/radio4000-supabase/blob/main/04-radio4000.sql
 export const deleteUser = async () => {

--- a/tests/channel.js
+++ b/tests/channel.js
@@ -1,0 +1,23 @@
+// Meant to be run in the local server.
+const sdk = window.sdk
+
+/**
+ * Tests a few SDK methods by running and chaining them. This should always work.
+ * Creates a new channel, queries it by slug, updates the name and validates it worked.
+ * For now you need to pass it a user email and password.
+ *
+ * @param {string} slug - a new, unique slug for the channel to be created
+ * @param {object} user
+ * @param {string} user.email
+ * @param {string} user.password
+ */
+async function testChannels(slug, {email, password}) {
+	console.log('testing')
+	const {data: {user}} = await sdk.signIn({email, password})
+	await sdk.createChannel({name: 'Radio Test', slug: slug}, {id: user.id})
+	const {data: channel} = await sdk.findChannelBySlug(slug)
+	await sdk.updateChannel(channel.id, {name: 'updated'})
+	const {data: updatedChannel} = await sdk.findChannelBySlug(slug)
+	console.log('same channel', channel.id === updatedChannel.id, )
+	console.log('name field was updated', updatedChannel.name === 'updated')
+}

--- a/tests/channel.js
+++ b/tests/channel.js
@@ -1,5 +1,6 @@
 // Meant to be run in the local server.
-const sdk = window.sdk
+// const sdk = window.sdk
+import sdk from '../src/index'
 
 /**
  * Tests a few SDK methods by running and chaining them. This should always work.
@@ -7,17 +8,16 @@ const sdk = window.sdk
  * For now you need to pass it a user email and password.
  *
  * @param {string} slug - a new, unique slug for the channel to be created
- * @param {object} user
- * @param {string} user.email
- * @param {string} user.password
  */
-async function testChannels(slug, {email, password}) {
+async function doTheTests(slug, {email, password}) {
 	console.log('testing')
 	const {data: {user}} = await sdk.signIn({email, password})
-	await sdk.createChannel({name: 'Radio Test', slug: slug}, {id: user.id})
+	await sdk.createChannel(user.id, {name: 'Radio Test', slug: slug})
 	const {data: channel} = await sdk.findChannelBySlug(slug)
 	await sdk.updateChannel(channel.id, {name: 'updated'})
 	const {data: updatedChannel} = await sdk.findChannelBySlug(slug)
 	console.log('same channel', channel.id === updatedChannel.id, )
 	console.log('name field was updated', updatedChannel.name === 'updated')
+	const {data: track} = sdk.createTrack(user.id, channel.id, {url: 'https://www.youtube.com/watch?v=dA55o_18a-g', title: 'My new track'})
+	console.log('track was created', track.title === 'My new track')
 }

--- a/tests/channel.js
+++ b/tests/channel.js
@@ -12,12 +12,12 @@ import sdk from '../src/index'
 async function doTheTests(slug, {email, password}) {
 	console.log('testing')
 	const {data: {user}} = await sdk.signIn({email, password})
-	await sdk.createChannel(user.id, {name: 'Radio Test', slug: slug})
+	await sdk.createChannel({name: 'Radio Test', slug: slug})
 	const {data: channel} = await sdk.findChannelBySlug(slug)
 	await sdk.updateChannel(channel.id, {name: 'updated'})
 	const {data: updatedChannel} = await sdk.findChannelBySlug(slug)
 	console.log('same channel', channel.id === updatedChannel.id, )
 	console.log('name field was updated', updatedChannel.name === 'updated')
-	const {data: track} = sdk.createTrack(user.id, channel.id, {url: 'https://www.youtube.com/watch?v=dA55o_18a-g', title: 'My new track'})
+	const {data: track} = sdk.createTrack(channel.id, {url: 'https://www.youtube.com/watch?v=dA55o_18a-g', title: 'My new track'})
 	console.log('track was created', track.title === 'My new track')
 }


### PR DESCRIPTION
The channel methods all accepted an object as argument with everything inside. Now I feel we shouldn't create objects everywhere just because we can. Adjusted the arguments and tried to document it a bit.

tried to only use objects as arguments if there is more than one "logical" group of properties we pass to a method.


```js
function createChannel({channel, user}) {} // before
function createChannel(user_id, {name, slug}) {} // after
```

👀

plus added a "test" in ./tests. I was just playing with it inside the local dev server browser console.