### PR TITLE
Fix types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^18.15.8",
         "ava": "^5.2.0",
-        "typescript": "^5.0.2",
+        "typescript": "^5.0.4",
         "vite": "^4.2.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,13 +6,12 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/sdk.cjs",
   "module": "./dist/sdk.js",
+  "types": "./dist/types/main.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/main.d.ts",
-      "import": "./dist/sdk.js",
-      "require": "./dist/sdk.cjs"
+      "import": "./dist/sdk.js"
     }
   },
   "private": false,

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "dist"
   ],
   "module": "./dist/sdk.js",
-  "types": "./dist/types/main.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/main.d.ts",
       "import": "./dist/sdk.js"
     }
   },
+  "types": "./dist/types/main.d.ts",
   "private": false,
   "scripts": {
     "dev": "vite --port 3999",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-website": "vite build --config vite-website.config.js",
     "preview": "vite preview",
     "test": "ava",
-    "types": "tsc src/main.js --allowJs --declaration --emitDeclarationOnly --outDir dist/types"
+    "types": "tsc"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.12.1",
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/node": "^18.15.8",
     "ava": "^5.2.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.0.4",
     "vite": "^4.2.1"
   },
   "author": "radio4000",

--- a/src/auth.js
+++ b/src/auth.js
@@ -2,6 +2,9 @@ import {supabase} from './main.js'
 
 // Three wrappers around the auth methods from Supabase.
 
+/**
+ * @param {{email: string, password: string}} param0
+ */
 export const signUp = async ({email, password}) => {
 	return supabase.auth.signUp({email, password})
 }

--- a/src/create-sdk.js
+++ b/src/create-sdk.js
@@ -2,9 +2,22 @@ import * as auth from './auth.js'
 import * as users from './users.js'
 import * as channels from './channels.js'
 import * as tracks from './tracks.js'
+import { SupabaseClient } from '@supabase/supabase-js'
 
 export let supabase
 
+/** @typedef {Object} SDK
+ * @property {typeof auth} auth
+ * @property {typeof users} users
+ * @property {typeof channels} channels
+ * @property {typeof tracks} tracks
+ * @property {SupabaseClient} supabase
+
+/**
+ * Creates a new SDK instance with the given Supabase client.
+ * @param {SupabaseClient} supabaseClient
+ * @returns {SDK}
+ */
 export function createSdk(supabaseClient) {
 	if (!supabaseClient) throw Error('Pass in a Supabase client')
 

--- a/src/sdk-default.js
+++ b/src/sdk-default.js
@@ -1,5 +1,5 @@
-import {createClient} from '@supabase/supabase-js'
 // const {createClient} = await import('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm')
+import {createClient} from '@supabase/supabase-js'
 import {createSdk} from './create-sdk.js'
 
 const supabase = createClient(
@@ -7,6 +7,9 @@ const supabase = createClient(
 	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTY0MTQxNTQ3MiwiZXhwIjoxOTU2OTkxNDcyfQ.gySR3Lv-m_CIj2Eyx6kfyOdwwMXEOFOgeHSjADqcM4Y'
 )
 
+/**
+ * The default Radio4000 SDK connects to the main Supabase project.
+ */
 const sdk = createSdk(supabase)
 
 export default sdk

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,16 @@
 {
+	"include": [
+		"src/**/*"
+	],
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
 		"esModuleInterop": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		// "declarationMap": true,
+		"moduleResolution": "nodenext",
+		"outDir": "./dist/types",
 		"target": "ES2020"
 	},
-	"include": [
-		"src/**/*",
-		"tests/**/*"
-	]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
 			name: 'radio4000Sdk',
 			// the proper extensions will be added
 			fileName: 'sdk',
-			formats: ['es', 'cjs'],
+			formats: ['es'],
 		},
 		rollupOptions: {
 			// We don't do this, because we want supabase-js inside our own bundle for ease.


### PR DESCRIPTION
After upgrading the build last I somehow broke the generated jsdoc types, meaning no more autocomplete for people using the sdk library.

This is an attempt to resolve that:

- `npm run types` wasn't using our tsconfig, now it is
- stop building `.cjs` format, only esm (maybe this breaks old node but we don't care)