### PR TITLE
More performance can edit

### DIFF
--- a/src/channels.js
+++ b/src/channels.js
@@ -166,18 +166,19 @@ export async function readChannelTracks(slug) {
 }
 
 /**
- * Checks if current user can edit a channel
+ * Checks if the local session user can edit a channel
  * @param {string} slug
  * @returns {Promise<Boolean>}
  */
 export async function canEditChannel(slug) {
-	const {data: user} = await readUser()
-	if (!user) return false
+	const {data: {session}} = await supabase.auth.getSession()
+	if (!session?.user) return false
+	// const {data: user} = await readUser()
 	const {data} = await supabase
 		.from('user_channel')
 		.select('user_id, channel_id!inner ( name, slug )')
 		.eq('channel_id.slug', slug)
-		.eq('user_id', user.id)
+		.eq('user_id', session.user.id)
 	if (data?.length > 0) return true
 	return false
 }

--- a/src/create-sdk.js
+++ b/src/create-sdk.js
@@ -6,6 +6,7 @@ import * as browse from './browse.js'
 
 export let supabase
 
+
 /** @typedef {import('@supabase/supabase-js').SupabaseClient} SupabaseClient */
 
 /** @typedef {Object} SDK

--- a/src/sdk-default.js
+++ b/src/sdk-default.js
@@ -13,3 +13,4 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
 const sdk = createSdk(supabase)
 
 export default sdk
+

--- a/src/users.js
+++ b/src/users.js
@@ -1,7 +1,7 @@
 import {supabase} from './main.js'
 
 /**
- * Gets the currently signed in user
+ * Fetches the currently signed in user
  * @param {string} [jwtToken]
  * @returns {Promise<{ data?: object, error?: object }>}
  */


### PR DESCRIPTION
We often check whether the local user is authorized to edit a channel using `sdk.canEditChannel()`. This works, but it _always_ tries to fetch a remote user, also when there is no local auth session.

If there is no local auth session, there is no need to fetch a user.

So this avoids an extra request on "can edit channel" function, and also an annoying failed request in the logs all the time.